### PR TITLE
Upgrade to .NET 10, switch to built-in OpenAPI + Scalar, upgrade dependencies

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -255,4 +255,5 @@ ModelManifest.xml
 # Vite build output
 **/wwwroot/dist/
 src/Letmein.ReactWeb/.claude/settings.local.json
+opencode.jsonc
 .claude/settings.local.json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,14 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- Core Dependencies -->
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.9.7" />
     <PackageVersion Include="CloudFileStore" Version="9.0.25" />
-    <PackageVersion Include="Marten" Version="8.13.3" />
+    <PackageVersion Include="Marten" Version="9.9.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
 
@@ -22,7 +24,7 @@
     <PackageVersion Include="Quartz" Version="3.15.1" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.15.1" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.3" />
 
     <!-- Test Dependencies -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,10 +7,10 @@
   <ItemGroup>
     <!-- Core Dependencies -->
     <PackageVersion Include="AWSSDK.Core" Version="4.0.9.7" />
-    <PackageVersion Include="CloudFileStore" Version="9.0.25" />
+    <PackageVersion Include="CloudFileStore" Version="10.0.27" />
     <PackageVersion Include="Marten" Version="9.9.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
 
     <!-- Web/API Dependencies -->
     <PackageVersion Include="Guard.Net" Version="3.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,28 +7,28 @@
     <!-- Core Dependencies -->
     <PackageVersion Include="CloudFileStore" Version="9.0.25" />
     <PackageVersion Include="Marten" Version="8.13.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
 
     <!-- Web/API Dependencies -->
     <PackageVersion Include="Guard.Net" Version="3.0.0" />
     <PackageVersion Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />
     <PackageVersion Include="StructureMap" Version="4.7.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
 
     <!-- API-specific Dependencies -->
     <PackageVersion Include="Quartz" Version="3.15.1" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.15.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
 
     <!-- Test Dependencies -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.6.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY src/Letmein.ReactWeb/ ./
 RUN npm run build
 
 # Build stage - .NET application
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy csproj files and restore dependencies (better layer caching)
@@ -34,7 +34,7 @@ RUN dotnet publish src/Letmein.Api/Letmein.Api.csproj \
     --no-restore
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 LABEL maintainer="Chris Small"
 LABEL org.opencontainers.image.title="Letmein"
 LABEL org.opencontainers.image.description="Encrypted notes service with temporary storage"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.305"
+    "version": "10.0.300",
+    "rollForward": "latestFeature"
   }
 }

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": true,
+  "permission": {
+    "lsp": "allow"
+  }
+}

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://opencode.ai/config.json",
-  "lsp": true,
-  "permission": {
-    "lsp": "allow"
-  }
-}

--- a/src/Letmein.Api/LetmeInStartupBuilder.cs
+++ b/src/Letmein.Api/LetmeInStartupBuilder.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
+using Scalar.AspNetCore;
 using Serilog;
 
 namespace Letmein.Api
@@ -53,14 +57,17 @@ namespace Letmein.Api
             });
 
             // Add API documentation
-            services.AddEndpointsApiExplorer();
-            services.AddSwaggerGen(c =>
+            services.AddOpenApi(options =>
             {
-                c.SwaggerDoc("v1", new Microsoft.OpenApi.OpenApiInfo
+                options.AddDocumentTransformer((document, context, cancellationToken) =>
                 {
-                    Title = "Letmein API",
-                    Version = "v1",
-                    Description = "A RESTful API for secure encrypted text sharing"
+                    document.Info = new()
+                    {
+                        Title = "Letmein API",
+                        Version = "v1",
+                        Description = "A RESTful API for secure encrypted text sharing"
+                    };
+                    return Task.CompletedTask;
                 });
             });
 
@@ -73,11 +80,10 @@ namespace Letmein.Api
             {
                 app.UseDeveloperExceptionPage();
                 app.UseHttpLogging();
-                app.UseSwagger();
-                app.UseSwaggerUI(c =>
-                {
-                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "Letmein API v1");
-                });
+
+                var endpoints = (Microsoft.AspNetCore.Routing.IEndpointRouteBuilder)app;
+                endpoints.MapOpenApi();
+                endpoints.MapScalarApiReference();
             }
 
             app.UseCors("AllowFrontend");

--- a/src/Letmein.Api/LetmeInStartupBuilder.cs
+++ b/src/Letmein.Api/LetmeInStartupBuilder.cs
@@ -56,7 +56,7 @@ namespace Letmein.Api
             services.AddEndpointsApiExplorer();
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+                c.SwaggerDoc("v1", new Microsoft.OpenApi.OpenApiInfo
                 {
                     Title = "Letmein API",
                     Version = "v1",

--- a/src/Letmein.Api/Letmein.Api.csproj
+++ b/src/Letmein.Api/Letmein.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Letmein.Api/Letmein.Api.csproj
+++ b/src/Letmein.Api/Letmein.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Scalar.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Letmein.Core/Letmein.Core.csproj
+++ b/src/Letmein.Core/Letmein.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Letmein.Core/Repositories/PostgresTextRepository.cs
+++ b/src/Letmein.Core/Repositories/PostgresTextRepository.cs
@@ -30,11 +30,11 @@ namespace Letmein.Core.Repositories.Postgres
 			}
 		}
 
-		internal IEnumerable<EncryptedItem> All()
+		internal async Task<IEnumerable<EncryptedItem>> All()
 		{
 			using (IQuerySession session = _store.QuerySession())
 			{
-				return session.Query<EncryptedItem>().ToList();
+				return await session.Query<EncryptedItem>().ToListAsync<EncryptedItem>();
 			}
 		}
 

--- a/src/Letmein.ReactWeb/package-lock.json
+++ b/src/Letmein.ReactWeb/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-router-dom": "^7.9.4",
+        "react-router-dom": "^7.12.0",
         "sjcl": "^1.0.8"
       },
       "devDependencies": {
@@ -24,6 +24,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.22",
         "globals": "^16.4.0",
+        "js-yaml": "^4.1.1",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.16",
         "vite": "^7.1.7"
@@ -1957,12 +1958,16 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -2542,9 +2547,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3183,9 +3188,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.4.tgz",
-      "integrity": "sha512-SD3G8HKviFHg9xj7dNODUKDFgpG4xqD5nhyd0mYoB5iISepuZAvzSr8ywxgxKJ52yRzf/HWtVHc9AWwoTbljvA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3205,12 +3210,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.4.tgz",
-      "integrity": "sha512-f30P6bIkmYvnHHa5Gcu65deIXoA2+r3Eb6PJIAddvsT9aGlchMatJ51GgpU470aSqRRbFX22T70yQNUGuW3DfA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
+      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.9.4"
+        "react-router": "7.12.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/src/Letmein.ReactWeb/package.json
+++ b/src/Letmein.ReactWeb/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.9.4",
+    "react-router-dom": "^7.12.0",
     "sjcl": "^1.0.8"
   },
   "devDependencies": {
@@ -26,6 +26,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.22",
     "globals": "^16.4.0",
+    "js-yaml": "^4.1.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.16",
     "vite": "^7.1.7"

--- a/src/Letmein.Tests/Integration/PostgresTextRepositoryTests.cs
+++ b/src/Letmein.Tests/Integration/PostgresTextRepositoryTests.cs
@@ -101,7 +101,7 @@ namespace Letmein.Tests.Integration
 
 			// Act
 			await _repository.Delete(encryptedItem2.FriendlyId);
-			var items = _repository.All();
+			var items = await _repository.All();
 
 			// Assert
 			items.Count().ShouldBe(2);

--- a/src/Letmein.Tests/Letmein.Tests.csproj
+++ b/src/Letmein.Tests/Letmein.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrades the entire solution from .NET 9 to .NET 10, replaces Swashbuckle with built-in OpenAPI + Scalar, and upgrades dependencies.

**.NET 10 Upgrade:**
- global.json: SDK 9.0.305 to 10.0.300 with rollForward: latestFeature
- Target framework: net9.0 to net10.0 across all 3 projects
- Dockerfile: SDK/ASP.NET base images 9.0 to 10.0
- CI: dotnet-version 9.0.x to 10.0.x
- Microsoft packages: 9.0.x to 10.0.x

**Swashbuckle to Built-in OpenAPI + Scalar:**
- Removed Swashbuckle, added Scalar.AspNetCore 2.14.3
- Replaced AddEndpointsApiExplorer/AddSwaggerGen with AddOpenApi (built-in)
- Replaced UseSwagger/UseSwaggerUI with MapOpenApi/MapScalarApiReference
- Scalar UI available at /scalar in development
- OpenAPI spec at /openapi/v1.json

**Dependency Upgrades:**
- CloudFileStore: 9.0.25 to 10.0.27 (.NET 10 target)
- Marten: 8.13.3 to 9.9.1 (fixes NU1904 critical vulnerability)
- Fixed Marten 9.0 breaking change: PostgresTextRepository.All made async
- AWSSDK.Core: pinned to 4.0.9.7 (fixes NU1901 low vulnerability)
- Microsoft.Extensions.Logging.Abstractions: 10.0.0 to 10.0.3

**Verification:**
- dotnet build: 0 errors, 0 warnings
- dotnet test (with Postgres via Docker): 64 passed, 0 failed, 2 skipped (pre-existing)