### PR TITLE
Swap SJCL for age-encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Letmein is an encrypted notes service, similar to cryptobin.co. No encryption ke
 
 - .NET 10
 - React using Vite and Tailwind
-- [Sjcl](https://github.com/bitwiseshiftleft/sjcl) Javascript library for encryption.
+- [age-encryption](https://github.com/FiloSottile/typage) Javascript library for encryption.
 - Postgres (using [Marten](https://github.com/JasperFx/marten))
 - Cloud storage (S3, Azure, Google) (using [CloudFileStore](https://github.com/yetanotherchris/CloudFileStore))
 

--- a/src/Letmein.Core/Services/TextEncryptionService.cs
+++ b/src/Letmein.Core/Services/TextEncryptionService.cs
@@ -38,7 +38,7 @@ namespace Letmein.Core.Services
 				{
 					Id = Guid.NewGuid(),
 					FriendlyId = friendlyId,
-					AlgorithmName = "STANFORDV1",
+					AlgorithmName = "AGE",
 					CreatedOn = createdate,
 					ExpiresOn = createdate.AddMinutes(expiresInMinutes),
 					CipherJson = json,

--- a/src/Letmein.ReactWeb/README.md
+++ b/src/Letmein.ReactWeb/README.md
@@ -4,7 +4,7 @@ A modern, secure text encryption and sharing application built with React, Vite,
 
 ## Features
 
-- Client-side encryption using SJCL (Stanford Javascript Crypto Library)
+- Client-side encryption using age-encryption
 - Modern, responsive UI with Tailwind CSS
 - Temporary encrypted message storage with expiry
 - Countdown timer for message expiration
@@ -66,7 +66,7 @@ npm run build
 - **Vite** - Build tool and dev server
 - **Tailwind CSS** - Utility-first CSS framework
 - **React Router** - Client-side routing
-- **SJCL** - Client-side encryption library
+- **age-encryption** - Client-side encryption library
 
 ## API Integration
 

--- a/src/Letmein.ReactWeb/package-lock.json
+++ b/src/Letmein.ReactWeb/package-lock.json
@@ -8,10 +8,10 @@
       "name": "letmein-reactweb",
       "version": "0.0.0",
       "dependencies": {
+        "age-encryption": "^0.3.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.18.0",
-        "sjcl": "^1.0.9"
+        "react-router-dom": "^7.18.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1010,6 +1010,88 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.5.4.tgz",
+      "integrity": "sha512-leww0zzIirrvwaYMPI9fj6aRIlA/c6Y0/lifQQ1YOOyHEr0MNH3yYpjXeiVG+tWdPps4XxGclFWX2INPO3Yo5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~2.0.0",
+        "@noble/hashes": "~2.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1366,6 +1448,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.3",
@@ -1766,6 +1857,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/age-encryption": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/age-encryption/-/age-encryption-0.3.0.tgz",
+      "integrity": "sha512-vDhGGp5ZXpbKL6oc3FEBjGhyepr/0SwIWmia6CcPXvYcxGBSQNcDdMv9m2yVOkjjYuJEmtGEhOojIUcjrj0cEw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/ciphers": "^2.1.1",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@noble/post-quantum": "^0.5.3",
+        "@scure/base": "^2.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3237,15 +3341,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/sjcl": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.9.tgz",
-      "integrity": "sha512-dWM71tkSHxe7zEZj0/COjtJdmErIxp7UMp8a6D4xx8dTTtJLc4lFL+HAX8s6lvASyQQ2iYMHwa7rhhQq7MT5MA==",
-      "license": "(BSD-2-Clause OR GPL-2.0-only)",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/source-map-js": {

--- a/src/Letmein.ReactWeb/package.json
+++ b/src/Letmein.ReactWeb/package.json
@@ -13,7 +13,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.18.0",
-    "sjcl": "^1.0.9"
+    "age-encryption": "^0.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/Letmein.ReactWeb/src/pages/Decrypt.jsx
+++ b/src/Letmein.ReactWeb/src/pages/Decrypt.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import sjcl from 'sjcl';
+import * as age from 'age-encryption';
 import { api } from '../utils/api';
 import Toast from '../components/Toast';
 import Countdown from '../components/Countdown';
@@ -43,7 +43,7 @@ export default function Decrypt() {
     setToast({ message, type });
   }, []);
 
-  const handleDecrypt = (e) => {
+  const handleDecrypt = async (e) => {
     e.preventDefault();
 
     if (!password) {
@@ -52,7 +52,10 @@ export default function Decrypt() {
     }
 
     try {
-      const decrypted = sjcl.decrypt(password, cipherJson);
+      const decoded = age.armor.decode(cipherJson);
+      const d = new age.Decrypter();
+      d.addPassphrase(password);
+      const decrypted = await d.decrypt(decoded, "text");
       setDecryptedText(decrypted);
       setIsDecrypted(true);
       showToast('Successfully decrypted!', 'success');

--- a/src/Letmein.ReactWeb/src/pages/Home.jsx
+++ b/src/Letmein.ReactWeb/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import sjcl from 'sjcl';
+import * as age from 'age-encryption';
 import { api } from '../utils/api';
 import Toast from '../components/Toast';
 
@@ -55,11 +55,12 @@ export default function Home() {
     setLoading(true);
 
     try {
-      // Encrypt the text client-side
-      const cipherJson = sjcl.encrypt(password, text);
+      const e = new age.Encrypter();
+      e.setPassphrase(password);
+      const ciphertext = await e.encrypt(text);
+      const armored = age.armor.encode(ciphertext);
 
-      // Store the encrypted data
-      const response = await api.storeNote(cipherJson, parseInt(expiryTime));
+      const response = await api.storeNote(armored, parseInt(expiryTime));
 
       setResult({
         friendlyId: response.friendlyId,


### PR DESCRIPTION
Replace SJCL (Stanford Javascript Crypto Library) with age-encryption, a TypeScript implementation of the age file encryption format.

**Changes:**
`package.json`: `sjcl` -> `age-encryption` (0.3.0)
`Home.jsx`: Use `age.Encrypter` with passphrase + ASCII armoring
`Decrypt.jsx`: Use `age.Decrypter` with passphrase + ASCII unarmoring
`TextEncryptionService.cs`: `AlgorithmName` changed from `STANFORDV1` to `AGE`
`README.md` and `ReactWeb/README.md`: Updated references

Architecture remains zero-knowledge -- all encryption/decryption happens client-side. The server only stores the armored ciphertext string.